### PR TITLE
Update README.md

### DIFF
--- a/day1_morning/README.md
+++ b/day1_morning/README.md
@@ -213,7 +213,7 @@ OK, so now that we have a useful command, wouldn’t it be great to turn it into
 > Run this script in day1_morn directory and verify that you get the correct results 
 
 ```
-bash fasta_counter.sh ./
+bash fasta_counter.sh .
 ```
 
 Plotting genomic coverage in R


### PR DESCRIPTION
changed input to bash fasta_counter.sh to . instead of ./ so that it will print only one slash (e.g. ./Acinetobacter_baumannii.fna instead of .//Acinetobacter_baumannii.fna)